### PR TITLE
Fix a compilation error in l2tp.sh

### DIFF
--- a/l2tp.sh
+++ b/l2tp.sh
@@ -9,7 +9,7 @@ export PATH
 #=======================================================================#
 cur_dir=`pwd`
 
-libreswan_filename="libreswan-3.20"
+libreswan_filename="libreswan-3.27"
 download_root_url="http://dl.teddysun.com/files"
 
 rootness(){
@@ -421,7 +421,12 @@ compile_install(){
     tar -zxf ${libreswan_filename}.tar.gz
 
     cd ${cur_dir}/l2tp/${libreswan_filename}
-    echo "WERROR_CFLAGS =" > Makefile.inc.local
+        cat > Makefile.inc.local <<'EOF'
+WERROR_CFLAGS =
+USE_DNSSEC = false
+USE_DH31 = false
+USE_GLIBC_KERN_FLIP_HEADERS = true
+EOF
     make programs && make install
 
     /usr/local/sbin/ipsec --version >/dev/null 2>&1


### PR DESCRIPTION
I created a brand new Ubuntu VPS running 18.04 in Vultr, but it failed to compile libreswan in this script. So I fixed it and submit this PR.

1. Fixed the script failed to compile in the Ubuntu 18.04 x64, kernel 4.15.0-36-generic.
2. Update libreswan to [3.27](https://download.libreswan.org/libreswan-3.27.tar.gz), you may need to upload this version file to your server if you merge the PR.

This fix was copy and modified from [hwdsl2/setup-ipsec-vpn](https://github.com/hwdsl2/setup-ipsec-vpn/blob/master/vpnsetup.sh#L199-L214). It is also used in [CentOS](https://github.com/hwdsl2/setup-ipsec-vpn/blob/master/vpnsetup_centos.sh#L199-L204).

Error  log:
```log
......
/root/l2tp/libreswan-3.27/programs/pluto/ikev2_ipseckey.c:28:10: fatal error: ldns/ldns.h: No such file or directory
 #include <ldns/ldns.h> /* from ldns-devel */
          ^~~~~~~~~~~~~
compilation terminated.
../../mk/depend.mk:34: recipe for target 'ikev2_ipseckey.o' failed
make[3]: *** [ikev2_ipseckey.o] Error 1
../../mk/targets.mk:82: recipe for target 'all' failed
make[2]: *** [all] Error 2
make[2]: Leaving directory '/root/l2tp/libreswan-3.27/programs/pluto'
../mk/targets.mk:82: recipe for target 'recursive-all' failed
make[1]: *** [recursive-all] Error 2
make[1]: Leaving directory '/root/l2tp/libreswan-3.27/programs'
mk/targets.mk:82: recipe for target 'recursive-all' failed
make: *** [recursive-all] Error 2
libreswan-3.27 install failed.
```
Same error with libreswan 3.20.