### PR TITLE
Update wireguard.sh

### DIFF
--- a/wireguard.sh
+++ b/wireguard.sh
@@ -511,7 +511,7 @@ add_client() {
         fi
     done
     # Get information from default interface file
-    client_files=($(find /etc/wireguard -name "*_client" | sort))
+    client_files=($(find /etc/wireguard/ -name "*_client" | sort))
     client_ipv4=()
     client_ipv6=()
     for ((i=0; i<${#client_files[@]}; i++)); do
@@ -632,7 +632,7 @@ list_clients() {
     local line="+-------------------------------------------------------------------------+\n"
     local string=%-35s
     printf "${line}|${string} |${string} |\n${line}" " Client Interface" " Client's IP"
-    client_files=($(find /etc/wireguard -name "*_client" | sort))
+    client_files=($(find /etc/wireguard/ -name "*_client" | sort))
     ips=($(grep -w "AllowedIPs" ${default_server_if} | awk '{print $3}'))
     [ ${#client_files[@]} -ne ${#ips[@]} ] && echo "One or more client interface file is missing in /etc/wireguard" && exit 1
     for ((i=0; i<${#ips[@]}; i++)); do


### PR DESCRIPTION
原先 client_files=($(find /etc/wireguard -name "*_client" | sort)) 在软连接目录下无法查询，需多个反斜杠