### PR TITLE
Alter the args for apt-get in func `install_wg_3`

### DIFF
--- a/wireguard.sh
+++ b/wireguard.sh
@@ -372,13 +372,13 @@ install_wg_3() {
         ubuntu)
             _error_detect "add-apt-repository ppa:wireguard/wireguard"
             _error_detect "apt-get update"
-            _error_detect "apt-get -y install wireguard-tools"
+            _error_detect "apt-get -y install --no-install-recommends wireguard-tools"
             ;;
         debian)
             echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable.list
             printf 'Package: *\nPin: release a=unstable\nPin-Priority: 90\n' > /etc/apt/preferences.d/limit-unstable
             _error_detect "apt-get update"
-            _error_detect "apt-get -y install wireguard-tools"
+            _error_detect "apt-get -y install --no-install-recommends wireguard-tools"
             ;;
         fedora)
             _error_detect "dnf -y copr enable jdoss/wireguard"


### PR DESCRIPTION
Do not install recommended packages while installing the `wireguard-tools` on a Debian-based OS running kernel newer than 5.6
当在内核版本大于 5.6 的 Debian 系发行版上使用从 repo 安装 wireguard 功能时，调整 apt-get 参数，使之不再主动安装 `wireguard-tools` 包列为 `建议` 包的其他软件包。

改动理由：
`wireguard-tools` 包下列为 `建议` 包的软件包包括 `wireguard-modules`，但是该套件暂时不可用，因此会安装 `wireguard-dkms` 代替。但在内核版本大于 5.6 的发行版上，安装 dkms 是不需要的，甚至会在更新 wireguard 时因为尝试更新 dkms 弹错误信息（这个无伤大雅，因为安装脚本只是检测到内核版本太新，警告用户 dkms 模块无需更新而已）
Refer: https://packages.ubuntu.com/focal/wireguard-tools