### PR TITLE
fix: fix processor name contain 'processor' issue

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -235,7 +235,7 @@ print_intro() {
 # Get System information
 get_system_info() {
     cname=$(awk -F: '/model name/ {name=$2} END {print name}' /proc/cpuinfo | sed 's/^[ \t]*//;s/[ \t]*$//')
-    cores=$(awk -F: '/processor/ {core++} END {print core}' /proc/cpuinfo)
+    cores=$(awk -F: '/^processor/ {core++} END {print core}' /proc/cpuinfo)
     freq=$(awk -F'[ :]' '/cpu MHz/ {print $4;exit}' /proc/cpuinfo)
     ccache=$(awk -F: '/cache size/ {cache=$2} END {print cache}' /proc/cpuinfo | sed 's/^[ \t]*//;s/[ \t]*$//')
     cpu_aes=$(grep -i 'aes' /proc/cpuinfo)


### PR DESCRIPTION
When model name contain processor, such as 'Common KVM processor', it will cause a false calculate in processor.

To prevent this, add ^ to make sure it only count the line start with processor.

Before:
<img width="406" alt="image" src="https://github.com/teddysun/across/assets/22383656/3bf53984-1f74-4545-b17b-bd6b77f9967a">

After:
<img width="395" alt="image" src="https://github.com/teddysun/across/assets/22383656/436362ab-a17f-4ad9-afc3-f42e3f5474e6">
