### PR TITLE
Update bench.sh: check_virt

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -159,6 +159,8 @@ check_virt() {
         virt="KVM"
     elif [[ "${sys_product}" == *KVM* ]]; then
         virt="KVM"
+    elif [[ "${sys_manu}" == *QEMU* ]]; then
+        virt="KVM"
     elif [[ "${cname}" == *KVM* ]]; then
         virt="KVM"
     elif [[ "${cname}" == *QEMU* ]]; then


### PR DESCRIPTION
Adjusted to recognize 'KVM' when 'sys_manu' contains 'QEMU'. (Detection was failing on BuyVM.net's KVM VPS)