### PR TITLE
Modify `io_test` to adapt to the Chinese environment

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -57,7 +57,7 @@ next() {
 
 speed_test() {
     local nodeName="$2"
-    if [ -z "$1" ];then 
+    if [ -z "$1" ];then
         ./speedtest-cli/speedtest --progress=no --accept-license --accept-gdpr >./speedtest-cli/speedtest.log 2>&1
     else
         ./speedtest-cli/speedtest --progress=no --server-id="$1" --accept-license --accept-gdpr >./speedtest-cli/speedtest.log 2>&1
@@ -90,7 +90,7 @@ speed() {
 }
 
 io_test() {
-    (LANG=C dd if=/dev/zero of=benchtest_$$ bs=512k count="$1" conv=fdatasync && rm -f benchtest_$$) 2>&1 | awk -F, '{io=$NF} END { print io}' | sed 's/^[ \t]*//;s/[ \t]*$//'
+    (LANG=C dd if=/dev/zero of=benchtest_$$ bs=512k count="$1" conv=fdatasync && rm -f benchtest_$$) 2>&1 | awk -F '[,，]' '{io=$NF} END { print io}' | sed 's/^[ \t]*//;s/[ \t]*$//'
 }
 
 calc_size() {
@@ -373,11 +373,11 @@ print_io_test() {
         io3=$(io_test ${writemb})
         echo " I/O Speed(3rd run) : $(_yellow "$io3")"
         ioraw1=$(echo "$io1" | awk 'NR==1 {print $1}')
-        [ "$(echo "$io1" | awk 'NR==1 {print $2}')" == "GB/s" ] && ioraw1=$(awk 'BEGIN{print '"$ioraw1"' * 1024}')
+        [[ "$(echo "$io1" | awk 'NR==1 {print $2}')" == "GB/s" ]] && ioraw1=$(awk 'BEGIN{print '"$ioraw1"' * 1024}')
         ioraw2=$(echo "$io2" | awk 'NR==1 {print $1}')
-        [ "$(echo "$io2" | awk 'NR==1 {print $2}')" == "GB/s" ] && ioraw2=$(awk 'BEGIN{print '"$ioraw2"' * 1024}')
+        [[ "$(echo "$io2" | awk 'NR==1 {print $2}')" == "GB/s" ]] && ioraw2=$(awk 'BEGIN{print '"$ioraw2"' * 1024}')
         ioraw3=$(echo "$io3" | awk 'NR==1 {print $1}')
-        [ "$(echo "$io3" | awk 'NR==1 {print $2}')" == "GB/s" ] && ioraw3=$(awk 'BEGIN{print '"$ioraw3"' * 1024}')
+        [[ "$(echo "$io3" | awk 'NR==1 {print $2}')" == "GB/s" ]] && ioraw3=$(awk 'BEGIN{print '"$ioraw3"' * 1024}')
         ioall=$(awk 'BEGIN{print '"$ioraw1"' + '"$ioraw2"' + '"$ioraw3"'}')
         ioavg=$(awk 'BEGIN{printf "%.1f", '"$ioall"' / 3}')
         echo " I/O Speed(average) : $(_yellow "$ioavg MB/s")"


### PR DESCRIPTION
When the system environment is Chinese, `io_test()` will throw an error. Therefore, in `io_test()`, we need to let `awk` use both Chinese and English commas as delimiters.

The error like this:

```
 I/O Speed(1st run) : 1073741824字节（1.1 GB，1.0 GiB）已复制，2.26661 s，474 MB/s
 I/O Speed(2nd run) : 1073741824字节（1.1 GB，1.0 GiB）已复制，2.22526 s，483 MB/s
 I/O Speed(3rd run) : 1073741824字节（1.1 GB，1.0 GiB）已复制，2.02646 s，530 MB/s
awk: 命令行:1: BEGIN{print 1073741824字节（1.1 + 1073741824字节（1.1 + 1073741824字节（1.1}
awk: 命令行:1:                       ^ 表达式中的无效字符“
awk: 命令行:1: BEGIN{print 1073741824字节（1.1 + 1073741824字节（1.1 + 1073741824字节（1.1}
awk: 命令行:1:                       ^ syntax error
awk: 命令行:1: BEGIN{printf "%.1f",  / 3}
awk: 命令行:1:                        ^ 未终止的正则表达式
awk: 命令行:1: BEGIN{printf "%.1f",  / 3}
awk: 命令行:1:                           ^ 未预期的新行或字符串结束
 I/O Speed(average) :  MB/s
```